### PR TITLE
Multiple Caches

### DIFF
--- a/src/xCache.Aop.Unity/CacheAttribute.cs
+++ b/src/xCache.Aop.Unity/CacheAttribute.cs
@@ -10,10 +10,11 @@ namespace xCache.Aop.Unity
         public int Hours { get; set; }
         public int Minutes { get; set; }
         public int Seconds { get; set; }
+        public string Name { get; set; }
 
         public override ICallHandler CreateHandler(IUnityContainer container)
         {
-            var cache = container.Resolve<ICache>();
+            var cache = container.Resolve<ICache>(Name);
             var keyGenerator = container.Resolve<ICacheKeyGenerator>();
 
             var handler = new CacheAttributeCallHandler(cache, keyGenerator)

--- a/src/xCache.Aop.Unity/CacheAttribute.cs
+++ b/src/xCache.Aop.Unity/CacheAttribute.cs
@@ -11,7 +11,6 @@ namespace xCache.Aop.Unity
         public int Minutes { get; set; }
         public int Seconds { get; set; }
         public string Name { get; set; }
-        public bool AbortMethodCallOnCacheMiss { get; set; }
 
         public override ICallHandler CreateHandler(IUnityContainer container)
         {
@@ -21,8 +20,7 @@ namespace xCache.Aop.Unity
             var handler = new CacheAttributeCallHandler(cache, keyGenerator)
             {
                 Order = Order,
-                Timeout = new TimeSpan(Hours, Minutes, Seconds),
-                AbortMethodCallOnCacheMiss = AbortMethodCallOnCacheMiss
+                Timeout = new TimeSpan(Hours, Minutes, Seconds)
             };
 
             //Set Default to 5

--- a/src/xCache.Aop.Unity/CacheAttribute.cs
+++ b/src/xCache.Aop.Unity/CacheAttribute.cs
@@ -11,6 +11,7 @@ namespace xCache.Aop.Unity
         public int Minutes { get; set; }
         public int Seconds { get; set; }
         public string Name { get; set; }
+        public bool AbortMethodCallOnCacheMiss { get; set; }
 
         public override ICallHandler CreateHandler(IUnityContainer container)
         {
@@ -19,8 +20,9 @@ namespace xCache.Aop.Unity
 
             var handler = new CacheAttributeCallHandler(cache, keyGenerator)
             {
-                Order = 1,
-                Timeout = new TimeSpan(Hours, Minutes, Seconds)
+                Order = Order,
+                Timeout = new TimeSpan(Hours, Minutes, Seconds),
+                AbortMethodCallOnCacheMiss = AbortMethodCallOnCacheMiss
             };
 
             //Set Default to 5

--- a/src/xCache.Aop.Unity/CacheAttributeCallHandler.cs
+++ b/src/xCache.Aop.Unity/CacheAttributeCallHandler.cs
@@ -9,7 +9,6 @@ namespace xCache.Aop.Unity
     {
         public int Order { get; set; }
         public TimeSpan Timeout { get; set; }
-        public bool AbortMethodCallOnCacheMiss { get; set; }
 
         private readonly ICache _cache;
         private readonly ICacheKeyGenerator _keyGenerator;
@@ -33,11 +32,6 @@ namespace xCache.Aop.Unity
             var cachedResult = _cache.GetType().GetMethod("Get")
                     .MakeGenericMethod(underlyingReturnType)
                     .Invoke(_cache, new object[] { cacheKey });
-
-            if (cachedResult == null && AbortMethodCallOnCacheMiss)
-            {
-                return input.CreateMethodReturn(null);
-            }
 
             // Nothing is cached for this method
             if (cachedResult == null || 
@@ -67,7 +61,7 @@ namespace xCache.Aop.Unity
                 {
                     cachedResult = typeof(Task).GetMethod("FromResult")
                         .MakeGenericMethod(methodInfo.ReturnType.GetGenericArguments())
-                        .Invoke(null, new object[] { cachedResult });
+                        .Invoke(null, new[] { cachedResult });
                 }
             }
 

--- a/src/xCache/CacheRecord.cs
+++ b/src/xCache/CacheRecord.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace xCache
+{
+    public class CacheRecord
+    {
+        public Guid Id { get; set; }
+
+        public DateTime Timestamp { get; set; }
+
+        public string Source { get; set; }
+
+        public string Key { get; set; }
+
+        public object Value { get; set; }
+
+        public CacheAction Action { get; set; }
+    }
+
+    public enum CacheAction
+    {
+        Get,
+        Add
+    }
+}

--- a/src/xCache/CacheRecorder.cs
+++ b/src/xCache/CacheRecorder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace xCache
+{
+    public static class CacheRecorder
+    {
+        public static ConcurrentStack<CacheRecord> Records = new ConcurrentStack<CacheRecord>();
+
+        public static void Record(string source, string key, object value, CacheAction cacheAction)
+        {
+            Records.Push(new CacheRecord
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.UtcNow,
+                Source = source,
+                Key = key,
+                Value = value,
+                Action = cacheAction
+            });
+        }
+    }
+}

--- a/src/xCache/DictionaryCache.cs
+++ b/src/xCache/DictionaryCache.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+
+namespace xCache
+{
+    public class DictionaryCache : ICache
+    {
+        private readonly IDictionary _cache;
+
+        public DictionaryCache(IDictionary cache)
+        {
+            _cache = cache;
+        }
+
+        public void Add<T>(string key, T item, TimeSpan expiration)
+        {
+            _cache[key] = item;
+        }
+
+        public T Get<T>(string key)
+        {
+            if (_cache.Contains(key))
+            {
+                var value = _cache[key];
+
+                if (value != null)
+                {
+                    return (T)value;
+                }
+            }
+            return default(T);
+        }
+    }
+}

--- a/src/xCache/DictionaryCache.cs
+++ b/src/xCache/DictionaryCache.cs
@@ -6,15 +6,21 @@ namespace xCache
     public class DictionaryCache : ICache
     {
         private readonly IDictionary _cache;
+        private readonly ICache _successor;
 
-        public DictionaryCache(IDictionary cache)
+        public DictionaryCache(IDictionary cache, ICache successor)
         {
             _cache = cache;
+            _successor = successor;
         }
 
         public void Add<T>(string key, T item, TimeSpan expiration)
         {
             _cache[key] = item;
+            if (_successor != null)
+            {
+                _successor.Add(key, item, expiration);
+            }
         }
 
         public T Get<T>(string key)
@@ -28,6 +34,12 @@ namespace xCache
                     return (T)value;
                 }
             }
+
+            if (_successor != null)
+            {
+                return _successor.Get<T>(key);
+            }
+
             return default(T);
         }
     }

--- a/src/xCache/xCache.csproj
+++ b/src/xCache/xCache.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DictionaryCache.cs" />
     <Compile Include="ICache.cs" />
     <Compile Include="MemoryCache.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/xCache/xCache.csproj
+++ b/src/xCache/xCache.csproj
@@ -40,6 +40,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CacheRecord.cs" />
+    <Compile Include="CacheRecorder.cs" />
     <Compile Include="DictionaryCache.cs" />
     <Compile Include="ICache.cs" />
     <Compile Include="MemoryCache.cs" />

--- a/tests/xCache.Tests.Aop.Unity/Core/UnityAop.cs
+++ b/tests/xCache.Tests.Aop.Unity/Core/UnityAop.cs
@@ -21,6 +21,12 @@ namespace xCache.Tests.Aop.Unity.Core
             return DateTime.Now.ToString();
         }
 
+        [Cache(Seconds = 1, Name = "Dictionary")]
+        public string GetCurrentDateAsStringOneSecondCache()
+        {
+            return DateTime.Now.ToString();
+        }
+
         [Cache(Seconds = 5)]
         public DateTime GetCurrentDateTimeFiveSecondCache()
         {

--- a/tests/xCache.Tests.Aop.Unity/Core/UnityAopTests.cs
+++ b/tests/xCache.Tests.Aop.Unity/Core/UnityAopTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Practices.Unity;
+﻿using System.Collections;
+using Microsoft.Practices.Unity;
 using Microsoft.Practices.Unity.InterceptionExtension;
 using xCache.Aop.Unity;
 using xCache.Tests.Core;
@@ -11,14 +12,16 @@ namespace xCache.Tests.Aop.Unity.Core
 
         public UnityAopTests()
         {    
+            DictionaryCache.Clear();
             _container = new UnityContainer();
 
             //Register interception
             _container.AddNewExtension<Interception>();
 
             //Register xCache
-            _container.RegisterType<ICache, MemoryCache>();
-            _container.RegisterType<ICache, DictionaryCache>("Dictionary");
+            _container.RegisterType<ICache, MemoryCache>(new InjectionConstructor(true));
+            _container.RegisterType<ICache, DictionaryCache>("Dictionary", new InjectionFactory(x =>
+                new DictionaryCache(DictionaryCache, _container.Resolve<ICache>(), true)));
             _container.RegisterType<ICacheKeyGenerator,JsonCacheKeyGenerator>();
 
             //Register test class with interception

--- a/tests/xCache.Tests.Aop.Unity/Core/UnityAopTests.cs
+++ b/tests/xCache.Tests.Aop.Unity/Core/UnityAopTests.cs
@@ -17,7 +17,8 @@ namespace xCache.Tests.Aop.Unity.Core
             _container.AddNewExtension<Interception>();
 
             //Register xCache
-            _container.RegisterType<ICache, xCache.MemoryCache>();
+            _container.RegisterType<ICache, MemoryCache>();
+            _container.RegisterType<ICache, DictionaryCache>("Dictionary");
             _container.RegisterType<ICacheKeyGenerator,JsonCacheKeyGenerator>();
 
             //Register test class with interception

--- a/tests/xCache.Tests/Core/AopTests.cs
+++ b/tests/xCache.Tests/Core/AopTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -7,6 +8,8 @@ namespace xCache.Tests.Core
 {
     public abstract class AopTests
     {
+        public static IDictionary DictionaryCache = new Hashtable();
+
         protected IAop _aop = null;
 
         [Fact]
@@ -119,6 +122,25 @@ namespace xCache.Tests.Core
             var result = await _aop.GetNullAsStringFiveSecondCacheAsync();
 
             Assert.Equal(result, null);
+        }
+
+        [Fact]
+        public void TestSecondLevelCache()
+        {
+            CacheRecord record;
+
+            _aop.GetCurrentDateAsStringOneSecondCache();
+            CacheRecorder.Records.TryPop(out record);
+            Assert.Equal("MemoryCache", record.Source);
+
+            _aop.GetCurrentDateAsStringOneSecondCache();
+            CacheRecorder.Records.TryPop(out record);
+            Assert.Equal("DictionaryCache", record.Source);
+
+            DictionaryCache.Clear();
+            _aop.GetCurrentDateAsStringOneSecondCache();
+            CacheRecorder.Records.TryPop(out record);
+            Assert.Equal("MemoryCache", record.Source);
         }
     }
 }

--- a/tests/xCache.Tests/Core/IAop.cs
+++ b/tests/xCache.Tests/Core/IAop.cs
@@ -11,5 +11,6 @@ namespace xCache.Tests.Core
         Task<DateTime> GetCurrentDateTimeFiveSecondCacheAsync();
         string GetNullAsStringFiveSecondCache();
         Task<string> GetNullAsStringFiveSecondCacheAsync();
+        string GetCurrentDateAsStringOneSecondCache();
     }
 }

--- a/tests/xCache.Tests/xCache.Tests.csproj
+++ b/tests/xCache.Tests/xCache.Tests.csproj
@@ -66,6 +66,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\xCache\xCache.csproj">
+      <Project>{b8006505-1377-4473-97aa-447095cf552f}</Project>
+      <Name>xCache</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
I created a DictionaryCache backing-store.  Multiple ICache implementations may be registered in Unity by name.  Unity interception was changed such that a cache-miss will return a null rather than invoke the underlying method.  

I'm not crazy about this.  Another alternative is to have a single CacheAttribute and the CacheAttributeCallHandler iterate through all registered ICache's.  I felt this offered less flexibility, though.  
